### PR TITLE
feat: tela de consulta e cadastro de clientes com service e CRUD

### DIFF
--- a/crud-angular-material/package-lock.json
+++ b/crud-angular-material/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/material": "^20.2.0",
         "@angular/platform-browser": "^20.1.0",
         "@angular/router": "^20.1.0",
+        "ngx-mask": "^20.0.3",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "uuid": "^11.0.2",
@@ -7397,6 +7398,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ngx-mask": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/ngx-mask/-/ngx-mask-20.0.3.tgz",
+      "integrity": "sha512-5bmrgbFGudj0mFN6cPv/TI+cFJxT4l61mLIFskdvaXsJL/Oj7thRmWYqvqHXjCboOcx8gT6T/Zypl5u9l2J8Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=14.0.0",
+        "@angular/core": ">=14.0.0",
+        "@angular/forms": ">=14.0.0"
       }
     },
     "node_modules/node-addon-api": {

--- a/crud-angular-material/package.json
+++ b/crud-angular-material/package.json
@@ -31,6 +31,7 @@
     "@angular/material": "^20.2.0",
     "@angular/platform-browser": "^20.1.0",
     "@angular/router": "^20.1.0",
+    "ngx-mask": "^20.0.3",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "uuid": "^11.0.2",

--- a/crud-angular-material/src/app/cadastro/cadastro.html
+++ b/crud-angular-material/src/app/cadastro/cadastro.html
@@ -1,6 +1,6 @@
 <div fxLayout = "row" fxLayoutAlign= "center">
   <div fxLayout ="column" fxFlex="800px" class = "container-form">
-    <form class="mt-60" #clientsFrm = "ngForm" (ngSubmit)="cadastrar()">
+    <form class="mt-60" #clientsFrm = "ngForm" (ngSubmit)="salvar()">
       <mat-card class="card">
         <mat-card-header>
           <mat-card-title>Dados Pessoais</mat-card-title>
@@ -30,7 +30,8 @@
               <div fxLayout="column" fxFlex="400px">
                 <mat-form-field class="full-width-formField">
                   <mat-label> Celular: *</mat-label>
-                  <input type="text" placeholder="Ex: (XX) 9XXXX-XXXX" matInput [(ngModel)]="cliente.telefone" name="telefone">
+                  <input type="text" placeholder="Ex: (XX) 9XXXX-XXXX" matInput [(ngModel)]="cliente.telefone" name="telefone"
+                  mask="(00)00000-0000">
                 </mat-form-field>
               </div>
             </div>
@@ -39,7 +40,8 @@
               <div fxLayout="column" fxFlex="400px">
                 <mat-form-field class="full-width-formField">
                   <mat-label> CPF: *</mat-label>
-                  <input type="text" placeholder="Digite seu CPF" matInput [(ngModel)]="cliente.cpf" name="cpf">
+                  <input type="text" placeholder="Digite seu CPF" matInput [(ngModel)]="cliente.cpf" name="cpf"
+                  mask="000.000.000-00">
                 </mat-form-field>
               </div>
             </div>
@@ -48,20 +50,23 @@
               <div fxLayout="column" fxFlex="400px">
                 <mat-form-field class="full-width-formField">
                   <mat-label> Data Nascimento: *</mat-label>
-                  <input type="date" placeholder="Digite sua data de nascimento" matInput [(ngModel)]="cliente.dataNascimento" name="dataNascimento">
+                  <input type="date" placeholder="Digite sua data de nascimento" matInput [(ngModel)]="cliente.dataNascimento" name="dataNascimento"
+                  mask="00/00/0000">
                 </mat-form-field>
               </div>
             </div>
 
             <mat-card-actions>
+              @if(!atualizando){
               <button mat-flat-button color="primary" type="submit">
                 <mat-icon fontIcon="save"></mat-icon>
                 Cadastrar
-              </button>
+              </button>}
+              @else{
               <button mat-flat-button color="primary">
                 <mat-icon fontIcon="refresh"></mat-icon>
                 Atualizar
-              </button>
+              </button>}
               <button mat-flat-button color="accent" class = "ml-5">
                 <mat-icon fontIcon="backspace"></mat-icon>
                 Limpar

--- a/crud-angular-material/src/app/cadastro/cadastro.ts
+++ b/crud-angular-material/src/app/cadastro/cadastro.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout'
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -6,32 +6,92 @@ import { MatCardModule } from '@angular/material/card'
 import { MatFormFieldModule } from '@angular/material/form-field'
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input'
+import { MatSnackBar } from '@angular/material/snack-bar'
+import { OnInit } from '@angular/core';
 
 import { Cliente } from './cliente'
 import { ClienteService } from '../clienteservice'
+import { v4 as uuid } from 'uuid';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { NgxMaskDirective, provideNgxMask } from 'ngx-mask'
 
 
 @Component({
   selector: 'app-cadastro',
-  imports: [FlexLayoutModule,
-            MatCardModule,
-            FormsModule,
-            MatFormFieldModule,
-            MatInputModule,
-            MatIconModule,
-            MatButtonModule
+  imports: [
+    FlexLayoutModule,
+    MatCardModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatButtonModule,
+    NgxMaskDirective
   ],
+  providers: provideNgxMask(),
   templateUrl: './cadastro.html',
   styleUrl: './cadastro.scss'
 })
-export class Cadastro {
+export class Cadastro implements OnInit{
+
   cliente: Cliente = Cliente.newClient();
-  constructor(private service: ClienteService) {
+  atualizando: boolean = false;
+  snack: MatSnackBar = inject(MatSnackBar)
 
+  constructor(private service: ClienteService,
+    private route:ActivatedRoute,
+    private router:Router
+  ) {}
 
+  ngOnInit(): void {
+    this.route.queryParamMap.subscribe( (query: any) => { // tem que "tipar" o parametro, daria para usar dtos aqui?
+      const params = query['params']
+      const id = params['id']
+      if(id){
+        let clienteEncontrado = this.service.buscarClientePorId(id)
+        if (clienteEncontrado){
+          this.atualizando = true;
+          this.cliente = clienteEncontrado;
+
+        }
+        // nao necessario pq o ja foi instanciado na tela
+        else{
+        this.cliente = Cliente.newClient()
+        }
+
+      }
+    })
   }
 
-  cadastrar(): void {
-    this.service.cadastrar(this.cliente) // aplica a lógica -> regra de services. Chama API, etc. Mais organização
+  salvar(): void {
+    if (!this.atualizando)
+    {
+     this.cadastrar();
+    }
+    else{
+      this.atualizar(this.cliente)
+      this.router.navigate(['/consulta'])
+    }
   }
+  cadastrar() : void {
+    this.cliente.id = uuid();
+
+    this.service.cadastrar(this.cliente);
+
+    this.SuccessMessage("Usuário cadastrado com sucesso")
+
+    this.cliente = Cliente.newClient();
+  }
+
+  atualizar(cliente : Cliente) : void { // aqui deveria chamar uma service que bate no endpoint de atualizar o usuario
+    this.service.atualizar(cliente)
+
+    this.SuccessMessage("Usuário atualizado com sucesso")
+  }
+
+  SuccessMessage(mensagem:string){
+    this.snack.open(mensagem, "Ok")
+  }
+
 }

--- a/crud-angular-material/src/app/cadastro/cliente.ts
+++ b/crud-angular-material/src/app/cadastro/cliente.ts
@@ -7,10 +7,10 @@ export class Cliente {
   dataNascimento?: string;
   email?: string;
   cpf?: string; // adicionado
+  deletando: boolean = false;
 
   static newClient() {
     const cliente = new Cliente();
-    cliente.id = uuid();
     return cliente;
   }
 }

--- a/crud-angular-material/src/app/clienteservice.ts
+++ b/crud-angular-material/src/app/clienteservice.ts
@@ -20,9 +20,46 @@ export class ClienteService {
     localStorage.setItem(ClienteService.REPO_CLIENTES, JSON.stringify(storage));
   }
 
+  atualizar(cliente: Cliente): void {
+    const storage = this.obterStorage();
+
+    // procura o índice do cliente existente pelo id
+    const index = storage.findIndex(c => c.id === cliente.id);
+
+    if (index !== -1) {
+      // substitui o cliente antigo pelo atualizado
+      storage[index] = cliente;
+      localStorage.setItem(ClienteService.REPO_CLIENTES, JSON.stringify(storage));
+    } else {
+      console.warn(`Cliente com id ${cliente.id} não encontrado para atualização`);
+    }
+  }
+
+  deletar(cliente: Cliente): void {
+    const storage = this.obterStorage();
+
+    // filtra removendo o cliente cujo id é igual ao informado
+    const novoStorage = storage.filter(c => c.id !== cliente.id);
+
+    // sobrescreve no localStorage
+    localStorage.setItem(ClienteService.REPO_CLIENTES, JSON.stringify(novoStorage));
+  }
+
   //f(x) que passa nome e retorna um array de clientes
-  pesquisarCliente(nome: string) : Cliente[]{
-    return this.obterStorage()
+  pesquisarCliente(nomeBusca: string) : Cliente[]{
+
+    const clientes = this.obterStorage()
+    if(!nomeBusca){
+      return clientes
+    }
+
+    return clientes.filter(cliente => cliente.nome?.toLowerCase().indexOf(nomeBusca.toLowerCase()) !== -1)
+  }
+
+  buscarClientePorId(id: string) : Cliente | undefined {
+    const clientes = this.obterStorage()
+
+    return clientes.find(clientes => clientes.id === id)
   }
 
   //f(x) que retorna todos os clientes

--- a/crud-angular-material/src/app/clienteservice.ts
+++ b/crud-angular-material/src/app/clienteservice.ts
@@ -20,7 +20,13 @@ export class ClienteService {
     localStorage.setItem(ClienteService.REPO_CLIENTES, JSON.stringify(storage));
   }
 
-  obterStorage() : Cliente[]{
+  //f(x) que passa nome e retorna um array de clientes
+  pesquisarCliente(nome: string) : Cliente[]{
+    return this.obterStorage()
+  }
+
+  //f(x) que retorna todos os clientes
+  private obterStorage() : Cliente[]{
     const dbClientes = localStorage.getItem(ClienteService.REPO_CLIENTES)
     if (dbClientes)
       {

--- a/crud-angular-material/src/app/consulta/consulta.html
+++ b/crud-angular-material/src/app/consulta/consulta.html
@@ -1,19 +1,18 @@
 <div fxLayout = "row" fxLayoutAlign = "center">
   <div fxLayout = "column" fxFlex = "1000px">
-    <form class="mt-60" #buscarForm = "ngForm">
+    <form class="mt-60" #buscarForm = "ngForm" (ngSubmit)="pesquisar()">
       <mat-card appearance="outlined">
         <mat-card-header>
           <mat-card-title>
             Consulta
           </mat-card-title>
         </mat-card-header>
-
         <mat-card-content class="mt-20">
           <div fxLayout = "row">
             <div fxLayout = "column" fxFlex = "950px">
               <mat-form-field class="full-width-formField">
                 <mat-label>Nome:</mat-label>
-                <input matInput placeholder="ex: Jose">
+                <input name = "nomeBusca" [(ngModel)] ="nomeBusca" matInput placeholder="ex: Jose">
               </mat-form-field>
             </div>
           </div>
@@ -24,7 +23,69 @@
           </button>
         </mat-card-actions>
       </mat-card>
-
     </form>
   </div>
+</div>
+
+<div fxLayout = "row" fxLayoutAlign = "center" class="mt-10">
+    <div fxLayout = "column" fxFlex = "1000px">
+      <mat-card appearance="outlined">
+        <mat-card-header>
+          <mat-card-title>
+            Resultado
+          </mat-card-title>
+        </mat-card-header>
+          <mat-card-content>
+            <table mat-table [dataSource]="listaClientes" class="mat-elevation-z8 full-width-table">
+
+              <!-- ID Column -->
+              <ng-container matColumnDef="id">
+                <th mat-header-cell *matHeaderCellDef> ID </th>
+                <td mat-cell *matCellDef="let cliente"> {{cliente.id}} </td>
+              </ng-container>
+
+              <!-- Nome Column -->
+              <ng-container matColumnDef="nome">
+                <th mat-header-cell *matHeaderCellDef> Nome </th>
+                <td mat-cell *matCellDef="let cliente"> {{cliente.nome}} </td>
+              </ng-container>
+
+              <!-- Email Column -->
+              <ng-container matColumnDef="email">
+                <th mat-header-cell *matHeaderCellDef> Email </th>
+                <td mat-cell *matCellDef="let cliente"> {{cliente.email}} </td>
+              </ng-container>
+
+              <!-- CPF Column -->
+              <ng-container matColumnDef="cpf">
+                <th mat-header-cell *matHeaderCellDef> CPF </th>
+                <td mat-cell *matCellDef="let cliente"> {{cliente.cpf}} </td>
+              </ng-container>
+
+              <ng-container matColumnDef="acoes">
+                <th mat-header-cell *matHeaderCellDef></th>
+                <td mat-cell *matCellDef="let cliente">
+                  <button type="button" mat-button (click) = "preparaEditar(cliente.id)">
+                    <mat-icon fontIcon="edit"></mat-icon>
+                  </button>
+                  @if(!cliente.deletando){
+                  <button type="button" mat-button (click) = "preparaDeletar(cliente)">
+                    <mat-icon fontIcon="delete"></mat-icon>
+                  </button>
+                }
+                @else{
+                  <button type="button" mat-button (click) = "deletar(cliente)" color="red">
+                    <mat-icon fontIcon="clear"></mat-icon>
+                  </button>
+                }
+              </ng-container>
+
+
+              <!-- Header & Row -->
+              <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+            </table>
+          </mat-card-content>
+        </mat-card>
+    </div>
 </div>

--- a/crud-angular-material/src/app/consulta/consulta.html
+++ b/crud-angular-material/src/app/consulta/consulta.html
@@ -1,1 +1,30 @@
-<p>consulta works!</p>
+<div fxLayout = "row" fxLayoutAlign = "center">
+  <div fxLayout = "column" fxFlex = "1000px">
+    <form class="mt-60" #buscarForm = "ngForm">
+      <mat-card appearance="outlined">
+        <mat-card-header>
+          <mat-card-title>
+            Consulta
+          </mat-card-title>
+        </mat-card-header>
+
+        <mat-card-content class="mt-20">
+          <div fxLayout = "row">
+            <div fxLayout = "column" fxFlex = "950px">
+              <mat-form-field class="full-width-formField">
+                <mat-label>Nome:</mat-label>
+                <input matInput placeholder="ex: Jose">
+              </mat-form-field>
+            </div>
+          </div>
+        </mat-card-content>
+        <mat-card-actions>
+          <button type="submit" mat-flat-button color="primary">
+            <mat-icon fontIcon="search"></mat-icon>Pesquisar
+          </button>
+        </mat-card-actions>
+      </mat-card>
+
+    </form>
+  </div>
+</div>

--- a/crud-angular-material/src/app/consulta/consulta.ts
+++ b/crud-angular-material/src/app/consulta/consulta.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -8,7 +9,9 @@ import { MatInputModule } from '@angular/material/input';
 import { MatTableModule } from '@angular/material/table';
 import { ClienteService } from '../clienteservice';
 import { Cliente } from '../cadastro/cliente';
+import { Router } from '@angular/router';
 
+import { MatSnackBar } from '@angular/material/snack-bar'
 
 @Component({
   selector: 'app-consulta',
@@ -22,14 +25,42 @@ import { Cliente } from '../cadastro/cliente';
   templateUrl: './consulta.html',
   styleUrl: './consulta.scss'
 })
-export class Consulta {
+export class Consulta implements OnInit {
 
+  nomeBusca : string= ''
   listaClientes : Cliente[] = [];
+  displayedColumns: string[] = ['id', 'nome', 'email', 'cpf', 'acoes'];
 
-  constructor(private service: ClienteService){
+  snack: MatSnackBar = inject(MatSnackBar)
+
+  constructor(private service: ClienteService,
+    private router: Router
+  ){
 
   }
   ngOnInit(){
-    this.listaClientes = this.service.pesquisarCliente("");
+    this.listaClientes = this.service.pesquisarCliente('');
+  }
+
+  pesquisar(){
+    this.listaClientes = this.service.pesquisarCliente(this.nomeBusca)
+  }
+
+  preparaEditar(id: string){
+    this.router.navigate(['/cadastro'], {queryParams : {"id" : id}}
+    )
+  }
+  preparaDeletar(cliente: Cliente)
+  {
+    cliente.deletando = true;
+  }
+  deletar(cliente : Cliente){
+    this.service.deletar(cliente);
+    this.listaClientes = this.service.pesquisarCliente('');
+    this.SuccessMessage("Usuário deletado com sucesso")
+  }
+
+  SuccessMessage(mensagem:string){
+    this.snack.open(mensagem, "Ok")
   }
 }

--- a/crud-angular-material/src/app/consulta/consulta.ts
+++ b/crud-angular-material/src/app/consulta/consulta.ts
@@ -1,11 +1,35 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatTableModule } from '@angular/material/table';
+import { ClienteService } from '../clienteservice';
+import { Cliente } from '../cadastro/cliente';
+
 
 @Component({
   selector: 'app-consulta',
-  imports: [],
+  imports: [MatInputModule,
+    MatCardModule,
+    MatTableModule,
+    MatIconModule,
+    MatButtonModule,
+    FlexLayoutModule,
+    FormsModule],
   templateUrl: './consulta.html',
   styleUrl: './consulta.scss'
 })
 export class Consulta {
 
+  listaClientes : Cliente[] = [];
+
+  constructor(private service: ClienteService){
+
+  }
+  ngOnInit(){
+    this.listaClientes = this.service.pesquisarCliente("");
+  }
 }

--- a/crud-angular-material/src/styles.scss
+++ b/crud-angular-material/src/styles.scss
@@ -38,6 +38,9 @@ body {
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
+.mt-10{
+  margin-top: 10px;
+}
 
 .mt-20{
   margin-top: 20px;


### PR DESCRIPTION
# feat: tela de consulta e cadastro de clientes com service e CRUD
## Descrição
Este PR implementa as telas de **Cadastro** e **Consulta** de clientes, além da estrutura inicial de **service** para persistência em `localStorage`.  
As alterações contemplam tanto a parte visual (HTML + Angular Material) quanto a lógica de cadastro, atualização e exclusão de clientes.  

---

## Commits incluídos
- **inicio da consulta, ngOnInit, estruturação do html mais rápida**  
  - Estrutura inicial da tela de consulta.  
  - Implementação do `ngOnInit` para carregar dados.  
  - Criação do HTML base para busca com Angular Material (`mat-form-field`, `mat-card`).  

- **services, mensagens, logica html e logica ts**  
  - Criação do `ClienteService` com os métodos `cadastrar`, `atualizar` e `deletar`.  
  - Integração entre o formulário de cadastro e o service.  
  - Ajustes de mensagens e lógica entre HTML e TS.  
  - Implementação da tabela (`mat-table`) para exibir os clientes cadastrados.  

---

## Principais mudanças técnicas
- Modelo `Cliente` atualizado com campos `id`, `nome`, `telefone`, `dataNascimento`, `email` e `cpf`.  
- Cadastro de cliente agora gera **UUID somente ao salvar**.  
- Adicionados métodos `cadastrar`, `atualizar` e `deletar` no `ClienteService` para CRUD completo.  
- Tela de consulta com campo de busca e exibição em `mat-table` (colunas: `id`, `nome`, `email`, `cpf`).  
- Ajustes visuais nos formulários com `mat-form-field` arredondado. 