### PR TITLE
feat: integração com BrasilAPI para seleção de UF e município

### DIFF
--- a/crud-angular-material/src/app/app.config.ts
+++ b/crud-angular-material/src/app/app.config.ts
@@ -1,12 +1,15 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
+import { provideHttpClient, withFetch } from '@angular/common/http'
+
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideHttpClient(withFetch())
   ]
 };

--- a/crud-angular-material/src/app/brasilapi.models.ts
+++ b/crud-angular-material/src/app/brasilapi.models.ts
@@ -1,0 +1,9 @@
+export interface Estado{
+  sigla: string;
+  nome: string;
+}
+
+export interface Municipio{
+  nome: string;
+  codigo_ibge: string;
+}

--- a/crud-angular-material/src/app/brasilapi.spec.ts
+++ b/crud-angular-material/src/app/brasilapi.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Brasilapi } from './brasilapi';
+
+describe('Brasilapi', () => {
+  let service: Brasilapi;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(Brasilapi);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/crud-angular-material/src/app/brasilapi.ts
+++ b/crud-angular-material/src/app/brasilapi.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class Brasilapi {
+  
+}

--- a/crud-angular-material/src/app/brasilapi.ts
+++ b/crud-angular-material/src/app/brasilapi.ts
@@ -1,8 +1,25 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Estado, Municipio } from './brasilapi.models';
 
 @Injectable({
   providedIn: 'root'
 })
 export class Brasilapi {
-  
+
+  baseURL: string = 'https://brasilapi.com.br/api'
+  constructor(private http: HttpClient) {}
+
+  listarUFs() : Observable<Estado[]> {// pelo que entendi é o Task<> do C# indicando que é uma operação assincrona
+    const path = '/ibge/uf/v1'
+
+    return this.http.get<Estado[]>(this.baseURL + path)
+  }
+
+  listarMunicipios(uf: string) : Observable<Municipio[]> {
+    const path = '/ibge/municipios/v1/' + uf
+
+    return this.http.get<Municipio[]>(this.baseURL+ path)
+  }
 }

--- a/crud-angular-material/src/app/cadastro/cadastro.html
+++ b/crud-angular-material/src/app/cadastro/cadastro.html
@@ -50,8 +50,34 @@
               <div fxLayout="column" fxFlex="400px">
                 <mat-form-field class="full-width-formField">
                   <mat-label> Data Nascimento: *</mat-label>
-                  <input type="date" placeholder="Digite sua data de nascimento" matInput [(ngModel)]="cliente.dataNascimento" name="dataNascimento"
+                  <input type="text" placeholder="Digite sua data de nascimento" matInput [(ngModel)]="cliente.dataNascimento" name="dataNascimento"
                   mask="00/00/0000">
+                </mat-form-field>
+              </div>
+            </div>
+
+            <div fxLayout="row" fxLayoutAlign="start" fxLayoutGap="16px">
+              <div fxLayout="column" fxFlex="400px">
+                <mat-form-field class="full-width-formField">
+                  <mat-label> UF: *</mat-label>
+                  <mat-select [(value)]="cliente.uf" (selectionChange)="carregarMunicipios($event)">
+                    <mat-option *ngFor="let uf of estados" [value]="uf.sigla">
+                      {{uf.sigla}}
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+            </div>
+
+            <div fxLayout="row" fxLayoutAlign="start" fxLayoutGap="16px">
+              <div fxLayout="column" fxFlex="400px">
+                <mat-form-field class="full-width-formField">
+                  <mat-label> Municipio: *</mat-label>
+                  <mat-select [(value)]="cliente.municipio" >
+                    <mat-option *ngFor="let m of municipios" [value]="m.nome">
+                      {{m.nome}}
+                    </mat-option>
+                  </mat-select>
                 </mat-form-field>
               </div>
             </div>

--- a/crud-angular-material/src/app/cadastro/cadastro.ts
+++ b/crud-angular-material/src/app/cadastro/cadastro.ts
@@ -7,6 +7,7 @@ import { MatFormFieldModule } from '@angular/material/form-field'
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input'
 import { MatSnackBar } from '@angular/material/snack-bar'
+import { MatSelectChange, MatSelectModule } from '@angular/material/select'
 import { OnInit } from '@angular/core';
 
 import { Cliente } from './cliente'
@@ -17,18 +18,22 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { NgxMaskDirective, provideNgxMask } from 'ngx-mask'
 import { Brasilapi } from '../brasilapi';
 import { Estado, Municipio } from '../brasilapi.models';
+import { CommonModule } from '@angular/common';
 
 
 @Component({
   selector: 'app-cadastro',
   imports: [
     FlexLayoutModule,
-    MatCardModule,
     FormsModule,
+    CommonModule,
+
+    MatCardModule,
     MatFormFieldModule,
     MatInputModule,
     MatIconModule,
     MatButtonModule,
+    MatSelectModule,
     NgxMaskDirective
   ],
   providers: provideNgxMask(),
@@ -42,7 +47,7 @@ export class Cadastro implements OnInit{
   snack: MatSnackBar = inject(MatSnackBar);
 
   estados: Estado[] = [];
-  municipio: Municipio[] =[];
+  municipios: Municipio[] =[];
 
   constructor(
     private service: ClienteService,
@@ -62,6 +67,10 @@ export class Cadastro implements OnInit{
         if (clienteEncontrado){
           this.atualizando = true;
           this.cliente = clienteEncontrado;
+          if (this.cliente.uf){
+            const event = {value: this.cliente.uf}
+            this.carregarMunicipios(event as MatSelectChange);
+          }
 
         }
         // nao necessario pq o ja foi instanciado na tela
@@ -108,8 +117,12 @@ export class Cadastro implements OnInit{
     })
   }
 
-  carregarMunicipios(uf : string){
-    return this.brasilService.listarMunicipios
+  carregarMunicipios(event : MatSelectChange){
+    const ufSelecionada = event.value;
+    this.brasilService.listarMunicipios(ufSelecionada).subscribe({
+      next: listaMunicipios => this.municipios = listaMunicipios,
+      error: erro => console.log("Ocorreu um erro", erro)
+    })
   }
 
   SuccessMessage(mensagem:string){

--- a/crud-angular-material/src/app/cadastro/cadastro.ts
+++ b/crud-angular-material/src/app/cadastro/cadastro.ts
@@ -15,6 +15,8 @@ import { v4 as uuid } from 'uuid';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { NgxMaskDirective, provideNgxMask } from 'ngx-mask'
+import { Brasilapi } from '../brasilapi';
+import { Estado, Municipio } from '../brasilapi.models';
 
 
 @Component({
@@ -37,14 +39,21 @@ export class Cadastro implements OnInit{
 
   cliente: Cliente = Cliente.newClient();
   atualizando: boolean = false;
-  snack: MatSnackBar = inject(MatSnackBar)
+  snack: MatSnackBar = inject(MatSnackBar);
 
-  constructor(private service: ClienteService,
+  estados: Estado[] = [];
+  municipio: Municipio[] =[];
+
+  constructor(
+    private service: ClienteService,
+    private brasilService: Brasilapi,
+
     private route:ActivatedRoute,
     private router:Router
   ) {}
 
   ngOnInit(): void {
+
     this.route.queryParamMap.subscribe( (query: any) => { // tem que "tipar" o parametro, daria para usar dtos aqui?
       const params = query['params']
       const id = params['id']
@@ -59,9 +68,9 @@ export class Cadastro implements OnInit{
         else{
         this.cliente = Cliente.newClient()
         }
-
       }
     })
+    this.carregarUFs()
   }
 
   salvar(): void {
@@ -88,6 +97,19 @@ export class Cadastro implements OnInit{
     this.service.atualizar(cliente)
 
     this.SuccessMessage("Usuário atualizado com sucesso")
+  }
+
+  carregarUFs()
+  {
+    // Observable: avisa alteracao; subscriver: recebe -> confirmado, é por ser requisicao assincrona que é observable
+    this.brasilService.listarUFs().subscribe({
+      next: listaEstados => this.estados = listaEstados,
+      error: erro => console.log("Ocorreu um erro", erro)
+    })
+  }
+
+  carregarMunicipios(uf : string){
+    return this.brasilService.listarMunicipios
   }
 
   SuccessMessage(mensagem:string){

--- a/crud-angular-material/src/app/cadastro/cliente.ts
+++ b/crud-angular-material/src/app/cadastro/cliente.ts
@@ -8,6 +8,8 @@ export class Cliente {
   email?: string;
   cpf?: string; // adicionado
   deletando: boolean = false;
+  uf?: string;
+  municipio?: string;
 
   static newClient() {
     const cliente = new Cliente();


### PR DESCRIPTION
# feat: integração com BrasilAPI para seleção de UF e município

## Descrição
Este PR implementa a integração com a **BrasilAPI** para popular um formulário de cadastro com os **estados (UFs)** do Brasil e, após a seleção da UF, exibir os **municípios correspondentes**.  
Além disso, o modelo `Cliente` foi atualizado para conter os campos `uf` e `municipio`.  

---

## Commits incluídos
- **criado .ts da api aberta**  
  - Criação do arquivo base para consumir a BrasilAPI.  
  - Definição da estrutura inicial de chamadas para UFs e municípios.  

- **models, requisição http e estruturação de service de api**  
  - Criação dos models para mapear os dados de UFs e municípios.  
  - Implementação do service com `HttpClient` para chamadas à API.  
  - Estruturação de métodos para obter lista de estados e municípios dinamicamente.  

- **utilizacao de APIs, form select, operacoes assincronas**  
  - Criação do formulário com `mat-select` para exibir UFs e municípios.  
  - Implementação da lógica assíncrona: ao selecionar uma UF, os municípios são carregados.  
  - Binding dos selects ao modelo `Cliente`.  
  - Atualização da classe `Cliente` para conter `uf` e `municipio`.  

---

## Principais mudanças técnicas
- **Cliente**: novo modelo com `uf` e `municipio`.  
- **Service BrasilAPI**: implementação de chamadas HTTP para buscar estados e municípios.  
- **Formulário**: campos `mat-select` conectados ao modelo `Cliente` usando `[(value)}`.  
- **Assíncrono**: carregamento dinâmico de municípios ao selecionar uma UF.  
